### PR TITLE
Fixed warning "unpack(): Type N: not enough input, need 4, have 1"

### DIFF
--- a/lib/Sinner/Phpseclib/Net/SSH2.php
+++ b/lib/Sinner/Phpseclib/Net/SSH2.php
@@ -2125,7 +2125,7 @@ class Net_SSH2 {
             switch (ord($payload[0])) {
                 case NET_SSH2_MSG_GLOBAL_REQUEST: // see http://tools.ietf.org/html/rfc4254#section-4
                     $this->_string_shift($payload, 1);
-                    extract(unpack('Nlength', $this->_string_shift($payload)));
+                    extract(unpack('Nlength', $this->_string_shift($payload, 4)));
                     $this->errors[] = 'SSH_MSG_GLOBAL_REQUEST: ' . utf8_decode($this->_string_shift($payload, $length));
 
                     if (!$this->_send_binary_packet(pack('C', NET_SSH2_MSG_REQUEST_FAILURE))) {


### PR DESCRIPTION
This commit fixes the following error:

`
[2017-01-23 10:56:27] exporters.CRITICAL: Exception in exporter ".._bundle.exporter.shop.article.webshop". {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\ContextErrorException(code: 0): Warning: unpack(): Type N: not enough input, need 4, have 1 at /vendor/sinner/phpseclib-bundle/lib/Sinner/Phpseclib/Net/SSH2.php:2128)","messages":["--- Start exporter \"bundle.exporter.shop.article.webshop\" ---"]} []`
